### PR TITLE
Populate container-to-ip before processing healthcheck

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -73,14 +73,16 @@ func (p *Poller) GetHealthCheckServices() (services []types.Service, err error) 
 	// process services
 	uuidToPrimaryIP := make(map[string]string)
 	for _, svc := range svcs {
-		if svc.HealthCheck.Port == 0 {
-			continue
-		}
 		for _, c := range svc.Containers {
 			if c.PrimaryIp == "" {
 				continue
 			}
 			uuidToPrimaryIP[c.UUID] = c.PrimaryIp
+		}
+	}
+	for _, svc := range svcs {
+		if svc.HealthCheck.Port == 0 {
+			continue
 		}
 		var servers []types.Server
 		for _, c := range svc.Containers {


### PR DESCRIPTION
It will fix 2 issues:

1) When sidekick has a healthcheck, but primary does not - before the fix, the primary container ip would never got into the ips list
2) As sidekick gets represented as a separate service in metadata, if the sidekick process gets processed first, the primary container ip won't be present in the list at this point.

https://github.com/rancher/rancher/issues/6305