### PR TITLE
Allow for healthchecks for Websockets

### DIFF
--- a/pkg/haproxy/haproxy_template.cfg
+++ b/pkg/haproxy/haproxy_template.cfg
@@ -32,6 +32,7 @@ mode {{$be.Protocol}}
 balance roundrobin
 {{if ne $be.RequestLine "" -}}
 option httpchk {{$be.RequestLine}}
+http-check expect status {{$be.ResponseStatus}}
 {{end -}}
 {{if ne $be.ResponseTimeout 0 -}}
 timeout check {{$be.ResponseTimeout}}


### PR DESCRIPTION
Hello, I have a service that allows only websocket connections and I would like to monitor it using healthchecks. I found that it's possible but the http-check configuration option is missing.

Example from https://www.haproxy.com/blog/websockets-load-balancing-with-haproxy/

```
## websocket health checking
  option httpchk GET / HTTP/1.1rnHost:\ ws.domain.comrnConnection:\ Upgrade\r\nUpgrade:\ websocket\r\nSec-WebSocket-Key:\ haproxy\r\nSec-WebSocket-Version:\ 13\r\nSec-WebSocket-Protocol:\ echo-protocol
  http-check expect status 101
```

Would it be possible to add `http-check` option to configuration?