### PR TITLE
use pgrep to identify which pid(s) haproxy must kill

### DIFF
--- a/pkg/haproxy/haproxy_reload.sh
+++ b/pkg/haproxy/haproxy_reload.sh
@@ -10,7 +10,8 @@ reload_haproxy(){
         fi
     fi
     # restart service
-    if haproxy -p /var/run/haproxy.pid -f $1 -sf $(cat /var/run/haproxy.pid); then
+    PIDLIST="$(pgrep -d ' ' -f '/usr/sbin/haproxy\s+-f\s+/etc/haproxy/haproxy.cfg')"
+    if /usr/sbin/haproxy -f $1 -D -p /var/run/haproxy.pid -sf $PIDLIST; then
         return 0
     else
         return 1


### PR DESCRIPTION
Using haproxy's pidfile appears to be unreliable. If the pidfile if absent or empty, the old process won't be killed.
With time, stale haproxy processes pile up and start exhausting resources, both on the healtcheck container side and on the services targets side.